### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ function createTask(job: AbstractBackgroundJob): AsyncTask {
 ## API for scheduler
 
 * `addSimpleIntervalJob(job: SimpleIntervalJob): void` - registers and starts a new job;
-* `addLongIntervalJob(job: SimpleIntervalJob): void` - registers and starts a new job with support for intervals longer than 24.85 days;
+* `addLongIntervalJob(job: LongIntervalJob): void` - registers and starts a new job with support for intervals longer than 24.85 days;
 * `addIntervalJob(job: SimpleIntervalJob | LongIntervalJob): void` - registers and starts new interval-based job;
 * `stop(): void` - stops all jobs, registered in the scheduler;
 * `getById(id: string): Job` - returns the job with a given id.


### PR DESCRIPTION
fix: correct parameter name in addLongIntervalJob()

Changed 'SimpleIntervalJob' to 'LongIntervalJob' in addLongIntervalJob() of README.md