### PR TITLE
Unified addJob method

### DIFF
--- a/lib/toadScheduler.ts
+++ b/lib/toadScheduler.ts
@@ -19,6 +19,9 @@ export class ToadScheduler {
     this.jobRegistry = {}
   }
 
+  /**
+   * @deprecated in favor of unified addJob method
+   */
   addIntervalJob(job: SimpleIntervalJob | LongIntervalJob) {
     if (!this.engines.simpleIntervalEngine) {
       this.engines.simpleIntervalEngine = new SimpleIntervalEngine()
@@ -28,10 +31,16 @@ export class ToadScheduler {
     this.engines.simpleIntervalEngine.add(job)
   }
 
+  /**
+   * @deprecated in favor of unified addJob method
+   */
   addLongIntervalJob(job: LongIntervalJob): void {
     return this.addIntervalJob(job)
   }
 
+  /**
+   * @deprecated in favor of unified addJob method
+   */
   addSimpleIntervalJob(job: SimpleIntervalJob): void {
     return this.addIntervalJob(job)
   }
@@ -45,6 +54,9 @@ export class ToadScheduler {
     }
   }
 
+  /**
+   * @deprecated in favor of unified addJob method
+   */
   addCronJob(job: CronJob): void {
     if (!this.engines.cronJobEngine) {
       this.engines.cronJobEngine = new CronJobEngine()
@@ -52,6 +64,16 @@ export class ToadScheduler {
 
     this.registerJob(job)
     this.engines.cronJobEngine.add(job)
+  }
+
+  addJob(job: Job): void {
+    if (job instanceof SimpleIntervalJob || job instanceof LongIntervalJob) {
+      this.addIntervalJob(job)
+    } else if (job instanceof CronJob) {
+      this.addCronJob(job)
+    } else {
+      throw new Error('Unsupported job type.')
+    }
   }
 
   stop(): void {


### PR DESCRIPTION
### Description:

This pull request simplifies the `ToadScheduler` by introducing a unified `addJob` method for job addition, deprecating the specific methods like `addIntervalJob` and `addCronJob`.

#### Rationale:
I chose this simple, single-method design over a polymorphic approach to maintain ease of use and understandability. The alternative considered was a more polymorphic design, where each job type would know how to add itself to the scheduler:

```typescript
abstract class Job {
  abstract addToScheduler(scheduler: ToadScheduler): void;
}

class SimpleIntervalJob extends Job {
  addToScheduler(scheduler: ToadScheduler): void {
    scheduler.AddIntervalJob(this);
  }
}
```

Instead, I used a straightforward approach where the `addJob` method internally determines the job type and delegates to the appropriate method:

```typescript
// Implemented approach
addJob(job: Job): void {
  if (job instanceof SimpleIntervalJob || job instanceof LongIntervalJob) {
    this.addIntervalJob(job);
  } else if (job instanceof CronJob) {
    this.addCronJob(job);
  } else {
    throw new Error('Unsupported job type.');
  }
}
```

This approach would follow the Open/Closed Principle more closely but was not adopted due to the stability and limited extension expected in our job types.

#### Impact:
The update simplifies adding jobs to the scheduler, making the codebase easier to maintain and understand while still allowing for internal specialization for different job types.