### PR TITLE
fix: Remove croner note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,6 @@ You can use CronJob instances for handling Cron-style scheduling:
       scheduler.addCronJob(job)
 ```
 
-Note that you need to install "croner" library for this to work. Run `npm i croner` in order to install this dependency.
-
 ## Usage in clustered environments
 
 `toad-scheduler` does not persist its state by design, and has no out-of-the-box concurrency management features. In case it is necessary


### PR DESCRIPTION
Closes #237 

Croner is a dependency of the package so there is no need to manually install it