### PR TITLE
fix: unify runImmediately lifecycle for SimpleIntervalJob and LongIntervalJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ Note that in order to avoid memory leaks, it is recommended to use promise chain
 Note that your error handlers can be asynchronous and return a promise. In such case an additional catch block will be attached to them, and should
 there be an error while trying to resolve that promise, and logging error will be logged using the default error handler (`console.error`).
 
+## Running a task immediately
+
+When you set `runImmediately: true` on `SimpleIntervalJob` or `LongIntervalJob`, the task fires once as part of `start()` (i.e. when you call `scheduler.addSimpleIntervalJob(job)` / `addLongIntervalJob(job)`), and then again on every interval tick.
+
+The library guarantees a specific ordering: the underlying interval timer is set up **before** the immediate run is fired. This matters if your task calls `job.stop()` (or `scheduler.stopById(jobId)`) on its very first run — the just-scheduled timer is still active and gets cleared, so no further runs happen.
+
+```ts
+const scheduler = new ToadScheduler()
+const jobId = 'one-shot-bootstrap'
+const task = new Task('bootstrap', () => {
+  doInitialWork()
+  scheduler.stopById(jobId)
+})
+const job = new SimpleIntervalJob(
+  { seconds: 60, runImmediately: true },
+  task,
+  { id: jobId },
+)
+scheduler.addSimpleIntervalJob(job)
+// task fires once now, then never again — no leftover 60s timer.
+```
+
+`runImmediately` is honored equally on `SimpleIntervalJob` and on `LongIntervalJob` (both for short intervals and for the long, "time-eating" path used when the interval exceeds setInterval's ~24.85-day cap).
+
 ## Preventing task run overruns
 
 In case you want to prevent second instance of a task from being fired up while first one is still executing, you can use `preventOverrun` options:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
         },
         resolve: {
           alias: {
-            croner: require('path').resolve(__dirname, 'node_modules/croner/dist/croner.cjs'),
+            croner: require('path').resolve(__dirname, 'node_modules/croner/dist/croner.min.cjs'),
           },
           extensions: ['.js', '.json', '.mjs', '.cjs', '.ts', '.tsx'],
         },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
         },
         resolve: {
           alias: {
-            croner: require('path').resolve(__dirname, 'node_modules/croner/dist/croner.min.cjs'),
+            croner: require('path').resolve(__dirname, 'node_modules/croner/dist/croner.cjs'),
           },
           extensions: ['.js', '.json', '.mjs', '.cjs', '.ts', '.tsx'],
         },

--- a/lib/engines/simple-interval/LongIntervalJob.ts
+++ b/lib/engines/simple-interval/LongIntervalJob.ts
@@ -72,25 +72,27 @@ export class LongIntervalJob extends Job {
   }
 
   start(): void {
+    if (this.childJob) {
+      this.childJob.start()
+    } else {
+      const time = toMsecs(this.schedule)
+      // Avoid starting duplicates and leaking previous timers
+      if (this.timer) {
+        this.stop()
+      }
+
+      this.timer = setInterval(() => {
+        if (!this.task.isExecuting || !this.preventOverrun) {
+          this.task.execute(this.id)
+        }
+      }, time)
+    }
+
+    // Fire after the underlying timer/childJob is in place so a stop()
+    // call from inside the immediate task can clear it (issue #176).
     if (this.schedule.runImmediately) {
       this.task.execute(this.id)
     }
-
-    if (this.childJob) {
-      return this.childJob.start()
-    }
-
-    const time = toMsecs(this.schedule)
-    // Avoid starting duplicates and leaking previous timers
-    if (this.timer) {
-      this.stop()
-    }
-
-    this.timer = setInterval(() => {
-      if (!this.task.isExecuting || !this.preventOverrun) {
-        this.task.execute(this.id)
-      }
-    }, time)
   }
 
   stop(): void {

--- a/lib/engines/simple-interval/LongIntervalJob.ts
+++ b/lib/engines/simple-interval/LongIntervalJob.ts
@@ -71,6 +71,18 @@ export class LongIntervalJob extends Job {
     this.childJob.start()
   }
 
+  /**
+   * Start the job.
+   *
+   * Lifecycle invariant: the underlying timer (or childJob, for the
+   * time-eating path used when the interval exceeds setInterval's
+   * ~24.85d cap) is brought up first, and any `runImmediately`
+   * execution happens last. Both paths share the rule, so a `stop()`
+   * issued from inside the immediate task always finds an active
+   * timer to clear (#176), and `runImmediately` is honored on the
+   * time-eating path too (#193, #212). `SimpleIntervalJob.start()`
+   * follows the same shape.
+   */
   start(): void {
     if (this.childJob) {
       this.childJob.start()
@@ -88,8 +100,6 @@ export class LongIntervalJob extends Job {
       }, time)
     }
 
-    // Fire after the underlying timer/childJob is in place so a stop()
-    // call from inside the immediate task can clear it (issue #176).
     if (this.schedule.runImmediately) {
       this.task.execute(this.id)
     }

--- a/lib/engines/simple-interval/LongIntervalJob.ts
+++ b/lib/engines/simple-interval/LongIntervalJob.ts
@@ -72,6 +72,10 @@ export class LongIntervalJob extends Job {
   }
 
   start(): void {
+    if (this.schedule.runImmediately) {
+      this.task.execute(this.id)
+    }
+
     if (this.childJob) {
       return this.childJob.start()
     }
@@ -80,10 +84,6 @@ export class LongIntervalJob extends Job {
     // Avoid starting duplicates and leaking previous timers
     if (this.timer) {
       this.stop()
-    }
-
-    if (this.schedule.runImmediately) {
-      this.task.execute(this.id)
     }
 
     this.timer = setInterval(() => {

--- a/lib/engines/simple-interval/SimpleIntervalJob.ts
+++ b/lib/engines/simple-interval/SimpleIntervalJob.ts
@@ -36,15 +36,17 @@ export class SimpleIntervalJob extends Job {
       this.stop()
     }
 
-    if (this.schedule.runImmediately) {
-      this.task.execute(this.id)
-    }
-
     this.timer = setInterval(() => {
       if (!this.task.isExecuting || !this.preventOverrun) {
         this.task.execute(this.id)
       }
     }, time)
+
+    // Run last so that stop() called from inside the immediate task
+    // can clear the just-scheduled timer (issue #176).
+    if (this.schedule.runImmediately) {
+      this.task.execute(this.id)
+    }
   }
 
   stop(): void {

--- a/lib/engines/simple-interval/SimpleIntervalJob.ts
+++ b/lib/engines/simple-interval/SimpleIntervalJob.ts
@@ -22,6 +22,15 @@ export class SimpleIntervalJob extends Job {
     this.task = task
   }
 
+  /**
+   * Start the job.
+   *
+   * Lifecycle invariant: the underlying timer is set up first, and any
+   * `runImmediately` execution happens last. A `stop()` call issued from
+   * inside the immediate task (sync) therefore finds an active timer to
+   * clear, preventing the dangling-timer / double-run bug from #176.
+   * `LongIntervalJob.start()` follows the same shape.
+   */
   start(): void {
     const time = toMsecs(this.schedule)
     // See https://github.com/kibertoad/toad-scheduler/issues/24
@@ -42,8 +51,6 @@ export class SimpleIntervalJob extends Job {
       }
     }, time)
 
-    // Run last so that stop() called from inside the immediate task
-    // can clear the just-scheduled timer (issue #176).
     if (this.schedule.runImmediately) {
       this.task.execute(this.id)
     }

--- a/test/LongIntervalJob.spec.ts
+++ b/test/LongIntervalJob.spec.ts
@@ -123,6 +123,33 @@ describe('ToadScheduler', () => {
       scheduler.stop()
     })
 
+    // https://github.com/kibertoad/toad-scheduler/issues/193
+    // https://github.com/kibertoad/toad-scheduler/issues/212
+    it('allows executing time-eating (>= 24.85d) job immediately', () => {
+      // ToDo investigate why this fails in Jasmine
+      if (isJasmine) {
+        return
+      }
+
+      let counter = 0
+      const scheduler = new ToadScheduler()
+      const task = new Task('simple task', () => {
+        counter++
+      })
+      const job = new LongIntervalJob(
+        {
+          days: 30,
+          runImmediately: true,
+        },
+        task,
+      )
+
+      expect(counter).toBe(0)
+      scheduler.addIntervalJob(job)
+      expect(counter).toBe(1)
+      scheduler.stop()
+    })
+
     it('correctly handles milliseconds', () => {
       let counter = 0
       const scheduler = new ToadScheduler()

--- a/test/LongIntervalJob.spec.ts
+++ b/test/LongIntervalJob.spec.ts
@@ -4,9 +4,6 @@ import { Task } from '../lib/common/Task'
 import { NoopTask } from './utils/testTasks'
 import { advanceTimersByTime, mockTimers, unMockTimers } from './utils/timerUtils'
 
-const isJest = process.env.JEST_WORKER_ID !== undefined
-const isJasmine = !isJest
-
 describe('ToadScheduler', () => {
   beforeEach(() => {
     mockTimers()
@@ -125,9 +122,7 @@ describe('ToadScheduler', () => {
 
     // https://github.com/kibertoad/toad-scheduler/issues/193
     // https://github.com/kibertoad/toad-scheduler/issues/212
-    // ToDo investigate why this fails in Jasmine
-    const itIfNotJasmine = isJasmine ? it.skip : it
-    itIfNotJasmine('allows executing time-eating (>= 24.85d) job immediately', () => {
+    it('allows executing time-eating (>= 24.85d) job immediately', () => {
       let counter = 0
       const scheduler = new ToadScheduler()
       const task = new Task('simple task', () => {
@@ -293,11 +288,6 @@ describe('ToadScheduler', () => {
     })
 
     it('correctly handles large intervals', () => {
-      // ToDo investigate why this fails in Jasmine
-      if (isJasmine) {
-        return
-      }
-
       let counter = 0
       const scheduler = new ToadScheduler()
       const task = new Task('simple task', () => {
@@ -342,11 +332,6 @@ describe('ToadScheduler', () => {
     })
 
     it('correctly handles large intervals repeatedly', () => {
-      // ToDo investigate why this fails in Jasmine
-      if (isJasmine) {
-        return
-      }
-
       let counter = 0
       const scheduler = new ToadScheduler()
       const task = new Task('simple task', () => {
@@ -379,11 +364,6 @@ describe('ToadScheduler', () => {
     })
 
     it('correctly handles very large intervals', () => {
-      // ToDo investigate why this fails in Jasmine
-      if (isJasmine) {
-        return
-      }
-
       let counter = 0
       const scheduler = new ToadScheduler()
       const task = new Task('simple task', () => {

--- a/test/LongIntervalJob.spec.ts
+++ b/test/LongIntervalJob.spec.ts
@@ -142,6 +142,61 @@ describe('ToadScheduler', () => {
       scheduler.stop()
     })
 
+    // https://github.com/kibertoad/toad-scheduler/issues/176
+    it('stop() inside an immediate sync run prevents subsequent runs (short path)', () => {
+      let counter = 0
+      const scheduler = new ToadScheduler()
+      const jobId = 'long-short-immediate-stop'
+      const task = new Task('simple task', () => {
+        counter++
+        scheduler.stopById(jobId)
+      })
+      const job = new LongIntervalJob(
+        {
+          seconds: 2,
+          runImmediately: true,
+        },
+        task,
+        { id: jobId },
+      )
+
+      scheduler.addIntervalJob(job)
+      expect(counter).toBe(1)
+      advanceTimersByTime(2000)
+      expect(counter).toBe(1)
+      advanceTimersByTime(2000)
+      expect(counter).toBe(1)
+
+      scheduler.stop()
+    })
+
+    // https://github.com/kibertoad/toad-scheduler/issues/176
+    it('stop() inside an immediate sync run prevents subsequent runs (time-eating path)', () => {
+      let counter = 0
+      const scheduler = new ToadScheduler()
+      const jobId = 'long-eating-immediate-stop'
+      const task = new Task('simple task', () => {
+        counter++
+        scheduler.stopById(jobId)
+      })
+      const job = new LongIntervalJob(
+        {
+          days: 30,
+          runImmediately: true,
+        },
+        task,
+        { id: jobId },
+      )
+
+      scheduler.addIntervalJob(job)
+      expect(counter).toBe(1)
+      // Advance well past one MAX_TIMEOUT_DURATION_MS chunk; chain should be stopped.
+      advanceTimersByTime(2_147_483_646)
+      expect(counter).toBe(1)
+
+      scheduler.stop()
+    })
+
     it('correctly handles milliseconds', () => {
       let counter = 0
       const scheduler = new ToadScheduler()

--- a/test/LongIntervalJob.spec.ts
+++ b/test/LongIntervalJob.spec.ts
@@ -125,12 +125,9 @@ describe('ToadScheduler', () => {
 
     // https://github.com/kibertoad/toad-scheduler/issues/193
     // https://github.com/kibertoad/toad-scheduler/issues/212
-    it('allows executing time-eating (>= 24.85d) job immediately', () => {
-      // ToDo investigate why this fails in Jasmine
-      if (isJasmine) {
-        return
-      }
-
+    // ToDo investigate why this fails in Jasmine
+    const itIfNotJasmine = isJasmine ? it.skip : it
+    itIfNotJasmine('allows executing time-eating (>= 24.85d) job immediately', () => {
       let counter = 0
       const scheduler = new ToadScheduler()
       const task = new Task('simple task', () => {

--- a/test/SimpleIntervalJob.spec.ts
+++ b/test/SimpleIntervalJob.spec.ts
@@ -221,6 +221,33 @@ describe('ToadScheduler', () => {
       scheduler.stop()
     })
 
+    // https://github.com/kibertoad/toad-scheduler/issues/176
+    it('stop() inside an immediate sync run prevents subsequent runs', () => {
+      let counter = 0
+      const scheduler = new ToadScheduler()
+      let job: SimpleIntervalJob
+      const task = new Task('simple task', () => {
+        counter++
+        job.stop()
+      })
+      job = new SimpleIntervalJob(
+        {
+          seconds: 2,
+          runImmediately: true,
+        },
+        task,
+      )
+
+      scheduler.addSimpleIntervalJob(job)
+      expect(counter).toBe(1)
+      advanceTimersByTime(2000)
+      expect(counter).toBe(1)
+      advanceTimersByTime(2000)
+      expect(counter).toBe(1)
+
+      scheduler.stop()
+    })
+
     it('correctly handles milliseconds', () => {
       let counter = 0
       const scheduler = new ToadScheduler()

--- a/test/SimpleIntervalJob.spec.ts
+++ b/test/SimpleIntervalJob.spec.ts
@@ -225,17 +225,18 @@ describe('ToadScheduler', () => {
     it('stop() inside an immediate sync run prevents subsequent runs', () => {
       let counter = 0
       const scheduler = new ToadScheduler()
-      let job: SimpleIntervalJob
+      const jobId = 'sync-immediate-stop'
       const task = new Task('simple task', () => {
         counter++
-        job.stop()
+        scheduler.stopById(jobId)
       })
-      job = new SimpleIntervalJob(
+      const job = new SimpleIntervalJob(
         {
           seconds: 2,
           runImmediately: true,
         },
         task,
+        { id: jobId },
       )
 
       scheduler.addSimpleIntervalJob(job)

--- a/test/utils/timerUtils.ts
+++ b/test/utils/timerUtils.ts
@@ -7,6 +7,11 @@ export function mockTimers() {
   }
   if (isJasmine) {
     jasmine.clock().install()
+    // jest.useFakeTimers() mocks Date by default; jasmine.clock().install()
+    // only mocks setTimeout/setInterval. Without mockDate(), Date.now() stays
+    // on the real wall clock and time-eating logic in LongIntervalJob loops
+    // forever because (mainTaskExecutionTime - Date.now()) never decreases.
+    jasmine.clock().mockDate(new Date())
   }
 }
 


### PR DESCRIPTION
## Summary

Consolidates fixes for three related runImmediately bugs across `SimpleIntervalJob` and `LongIntervalJob`. Previously each job type had a slightly different `start()` implementation, leading to a cluster of bugs that all stem from where `runImmediately` was placed relative to timer setup. This PR makes both job types follow one rule:

> **The underlying timer (or `childJob`, on `LongIntervalJob`'s time-eating path) is set up first, and `runImmediately` fires last.**

That single ordering closes all three bugs simultaneously:

- **#193 / #212** — `runImmediately` was being skipped on `LongIntervalJob`'s time-eating path because `start()` short-circuited through `if (this.childJob) return this.childJob.start()` before any `runImmediately` check. Now the immediate run fires after the path-specific timer setup, so both paths honor it.
- **#176** — `stop()` called from inside an immediate sync task became a no-op on `SimpleIntervalJob` because the interval timer hadn't been scheduled yet, leaving a dangling timer that produced an unintended second run. Setting up the timer first means `stop()` always finds an active timer to clear. The same shape now also protects `LongIntervalJob` from the same trap.

The README gets a new "Running a task immediately" section describing the contract; both `start()` methods get JSDoc explaining the invariant so future contributors don't accidentally drift the order back apart.

Closes #176
Closes #193
Closes #212
Supersedes #244

## Behavior contract for `runImmediately`
- The task fires once during `start()` (i.e. when added to the scheduler), then again on every interval tick.
- `stop()` (or `scheduler.stopById(...)`) called from inside that immediate run will cancel the just-scheduled timer; no further runs will happen.
- Honored equally on `SimpleIntervalJob` and on both `LongIntervalJob` paths (short and time-eating).

## Why the rule is "timer first, runImmediately last"
- `setInterval` callbacks can't run synchronously — they're always deferred by at least the delay — so there's no observable race where the first interval tick beats the immediate run.
- `stop()` inside the immediate task always finds an active timer to clear. This is what fixes #176.
- The childJob used in `LongIntervalJob`'s time-eating path is itself a `SimpleIntervalJob` with no `runImmediately` flag, so the rule applies recursively without double-firing.

## Other test-infrastructure fixes pulled in
- `mockTimers()` now calls `jasmine.clock().mockDate()` in addition to `install()`. Jest's `useFakeTimers()` mocks Date by default, but Jasmine's `clock().install()` does not — without this, `LongIntervalJob`'s time-eating logic (which reads `Date.now()` to compute remaining ms) loops forever. This was being papered over by `if (isJasmine) return` guards in three pre-existing tests; those guards are now removed.

## Test plan
- [x] Added regression test for `LongIntervalJob` + `days: 30` + `runImmediately: true` (covers #193/#212).
- [x] Added regression test for `SimpleIntervalJob` + sync task that calls `stop()` inside the immediate run (covers #176).
- [x] Added regression test for `LongIntervalJob` short path with `stop()` inside the immediate run (covers #176).
- [x] Added regression test for `LongIntervalJob` time-eating path with `stop()` inside the immediate run, advancing past `MAX_TIMEOUT_DURATION_MS` to verify the chain is fully torn down.
- [x] All previously-skipped Jasmine tests in `LongIntervalJob.spec.ts` now run and pass.
- [x] Lint, Jest (78/78), and `npm run test:karma` (78/78) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timer initialization order for jobs with `runImmediately: true` to ensure proper behavior when jobs stop themselves during execution.

* **Documentation**
  * Added README clarification on `runImmediately` execution guarantees and ordering behavior.

* **Tests**
  * Expanded test coverage for immediate execution behavior and self-stopping jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->